### PR TITLE
Fix undo bug v1.4

### DIFF
--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -118,6 +118,12 @@ public interface Model {
     void commitAddressBook();
 
     /**
+     * Replaces the current address book without
+     * updating the state pointer in the list
+     */
+    void replaceCurrentAddressBook();
+
+    /**
      * Checks if the given meeting overlaps with any existing meetings across all persons in the address book.
      * @param meeting The meeting to check.
      * @return true if there is an overlap, false otherwise.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -205,7 +205,7 @@ public class ModelManager implements Model {
                     updatedMeetings);
             setPerson(person, updatedPerson);
         });
-        commitAddressBook();
+        versionedAddressBook.replaceCurrentAddressBook();
     }
 }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -160,6 +160,10 @@ public class ModelManager implements Model {
     public void commitAddressBook() {
         versionedAddressBook.commit();
     }
+    @Override
+    public void replaceCurrentAddressBook() {
+        versionedAddressBook.replaceCurrentAddressBook();
+    }
 
     @Override
     public boolean equals(Object other) {
@@ -205,7 +209,7 @@ public class ModelManager implements Model {
                     updatedMeetings);
             setPerson(person, updatedPerson);
         });
-        versionedAddressBook.replaceCurrentAddressBook();
+        replaceCurrentAddressBook();
     }
 }
 

--- a/src/main/java/seedu/address/model/VersionedAddressBook.java
+++ b/src/main/java/seedu/address/model/VersionedAddressBook.java
@@ -2,12 +2,6 @@ package seedu.address.model;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
-
-import seedu.address.model.person.Meeting;
-import seedu.address.model.person.Person;
-
-
 
 /**
  * {@code AddressBook} that keeps track of its own history.
@@ -60,24 +54,7 @@ public class VersionedAddressBook extends AddressBook {
         }
         currentStatePointer--;
         ReadOnlyAddressBook prevState = addressBookStateList.get(currentStatePointer);
-        AddressBook filteredPrevState = new AddressBook();
-        prevState.getPersonList().forEach(person -> {
-            List<Meeting> updatedMeetings = person.getMeetings().stream()
-                    .filter(meeting -> !meeting.isExpired())
-                    .collect(Collectors.toList());
-            Person updatedPerson = new Person(
-                    person.getName(),
-                    person.getPhone(),
-                    person.getEmail(),
-                    person.getAddress(),
-                    person.getRelationship(),
-                    person.getPolicies(),
-                    person.getClientStatus(),
-                    person.getTags(),
-                    person.getMeetings());
-            filteredPrevState.addPerson(updatedPerson);
-        });
-        resetData(filteredPrevState);
+        resetData(prevState);
     }
 
 
@@ -91,6 +68,13 @@ public class VersionedAddressBook extends AddressBook {
         }
         currentStatePointer++;
         resetData(addressBookStateList.get(currentStatePointer));
+    }
+
+    /**
+     * Replaces the current address book without increasing the state pointer
+     */
+    public void replaceCurrentAddressBook() {
+        addressBookStateList.add(currentStatePointer, new AddressBook(this));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -190,6 +190,10 @@ public class AddCommandTest {
         public void commitAddressBook() {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public void replaceCurrentAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public boolean hasMeetingOverlap(Meeting meeting) {


### PR DESCRIPTION
Fix #200, Fix #153, Fix #156, Fix #119 

Issue has to do with expiry meetings resulting in a commit being done every minute. A commit increases the state pointer which means the function `canUndo` will return true. This means that users will be able to undo but it will not do anything as well as undo being able to be performed upon starting the app as the expiry meeting timer also starts then.
Fixed the bug by updating the address book state list without updating the pointer